### PR TITLE
Monitor received messages instead of subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Nagios WAMP V2 Web Socket Monitoring Plugin
 
 A Nagios NRPE script that allows you to monitor a web socket server using
 the *WAMP V2* protocol. While it is fairly easy with Nagios to monitor whether
-or not your server proccess is running, unfortunately that can't tell us
+or not your server process is running, unfortunately that can't tell us
 if that server is available and accepting connections.
 
 With nagios-wss you can actually open a connection to your websocket servers and
@@ -75,4 +75,4 @@ Define a new service for nagios-wss
 		check_command	check_wss_conn
 	}
 
-Resart the Nagios host.
+Restart the Nagios host.

--- a/check_wss_conn.py
+++ b/check_wss_conn.py
@@ -55,16 +55,6 @@ class Component(ApplicationSession):
             exit_code = EXIT_CODE_CRITICAL
             exit_message = 'CRITICAL - Connected, but no subscription made'
 
-        try:
-            message = json.loads('{"hello": "world", "test": "publish"}')
-            yield self.publish(
-                topic,
-                json.dumps(message)
-            )
-        except Exception as e:
-            exit_code = EXIT_CODE_CRITICAL
-            exit_message = 'Unable to publish to WAMP router! ' + str(e)
-
     def onLeave(self, details):
         """
         There is a bug in authobahn.wamp.protocol.py that always calls
@@ -108,6 +98,7 @@ if __name__ == '__main__':
         timeout = args.timeout
 
     def timeoutError():
+        print "Timed out!"
         reactor.stop() # This causes the runner.run() function to return.
 
     timeoutTimer = threading.Timer(timeout, timeoutError)

--- a/check_wss_conn.py
+++ b/check_wss_conn.py
@@ -25,13 +25,11 @@ topic = 'notifications.1'
 
 def timeoutError():
     receiveMessageEvent.clear()
-    exit_code = EXIT_CODE_CRITICAL
-    exit_message = "CRITICAL - process timed out before a message was received"
-    print exit_message
-    sys.exit(exit_code)
+    # exit_code = EXIT_CODE_CRITICAL
+    # exit_message = "CRITICAL - process timed out before a message was received"
+    # print exit_message
+    # sys.exit(exit_code)
 
-timeoutTimer = threading.Timer(10.0, timeoutError)
-timeoutTimer.start()
 
 receiveMessageEvent = threading.Event()
 
@@ -51,25 +49,25 @@ class Component(ApplicationSession):
         exit_code = EXIT_CODE_WARNING
         exit_message = 'Warning - Connected, but no subscription made'
 
-        def onEvent(msg):
-            # global exit_code
-            # global exit_message
-            # global topic
+        def onEvent(msg, options=None):
+            global exit_code
+            global exit_message
+            global topic
             print("Got event: {}".format(msg))
-
-            # exit_code = EXIT_CODE_NORMAL
-            # exit_message = 'OK - Socket session fully established'
-            # reactor.stop()
-            # receiveMessageEvent.set()
-
-        try:
-            yield self.subscribe(onEvent, topic)
-            print "Subscribed, waiting for event..."
 
             exit_code = EXIT_CODE_NORMAL
             exit_message = 'OK - Socket session fully established'
             reactor.stop()
             receiveMessageEvent.set()
+
+        try:
+            yield self.subscribe(onEvent, topic)
+            print "Subscribed, waiting for event..."
+
+            # exit_code = EXIT_CODE_NORMAL
+            # exit_message = 'OK - Socket session fully established'
+            # reactor.stop()
+            # receiveMessageEvent.set()
 
         except Exception:
             print "exception in onEvent!"
@@ -128,6 +126,9 @@ if __name__ == '__main__':
     if args.timeout is not None:
         timeout = args.timeout
 
+    timeoutTimer = threading.Timer(timeout, timeoutError)
+    timeoutTimer.start()
+
     try:
         if debug:
             log.startLogging(sys.stdout)
@@ -142,7 +143,7 @@ if __name__ == '__main__':
         exit_message = "CRITICAL - Unable to connect to socket server"
 
     while not receiveMessageEvent.wait(timeout=2.0): # every 2 seconds, see if we've received an event yet
-        print "Message hasn't been received yet..."
+        "Message hasn't been received yet..."
 
     timeoutTimer.cancel()
     print exit_message


### PR DESCRIPTION
This change changes the script so it waits for a subscription to actually send a message before exiting successfully.

It works properly on success but it currently doesn't terminate properly when the timeout Timer is triggered.
